### PR TITLE
Add `NOT` operator with Arrays support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - v6
+  - v5
+  - v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## `SLQ`
+## `SLQ` [![Build Status](https://travis-ci.org/umayr/slq.svg?branch=master)](https://travis-ci.org/umayr/slq)
 >Perform multi-level logical operations as a query over javascript object and/or array.
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -1,31 +1,48 @@
-## `slq`
->Perform simple logical query over an object
+## `SLQ`
+>Perform multi-level logical operations as a query over javascript object and/or array.
 
 ### Install
-
-Install it via npm:
 ```
   λ npm install --save slq
 ```
 
 ### Usage
-
 ```javascript
-  const Slq = require('slq');
-  const src = new Slq({
+  // require the library
+  const SLQ = require('slq');
+  // instantiate class object with either an object or an array
+  // for objects, it places the value for every key in the expression to evaluate
+  // valid existent key should be provided in the query
+  // for example, create instance with an object:
+  let src = new SLQ({
     foo: true,
     bar: false,
     baz: false
   });
+  // and, go wild
+  src.query('foo AND bar'); // false
+  src.query('foo AND NOT bar'); // true
+  src.query('NOT (foo AND NOT bar)'); // false
+  src.query('(foo AND bar) AND baz'); // false
+  src.query('NOT(NOT((foo AND bar) AND baz))'); // false
+  src.query('foo AND (bar AND baz)'); // false
+  src.query('foo AND (foo AND (bar AND baz))'); // false
+  src.query('foo AND (foo AND foo)'); // true
+  src.query('foo AND (foo OR bar)'); // true
+  src.query('foo OR (foo AND bar)'); // true
+  src.query('baz OR (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))'); // true
+  // there's no limit to how deep you want to go
+  src.query('NOT baz AND (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))'); // true
   
-  src.query('foo AND bar') // false
-  src.query('(foo AND bar) AND baz') // false
-  src.query('foo AND (bar AND baz)') // false
-  src.query('foo AND (foo AND (bar AND baz))') // false
-  src.query('foo AND (foo AND foo)') // true
-  src.query('foo AND (foo OR bar)') // true
-  src.query('foo OR (foo AND bar)') // true
-  src.query('baz OR (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))') // true
+  // for arrays, it checks if provided key is in the array or not
+  // for example:
+  let src = new SLQ(['foo', 'bar', 'unicorn']);
+  
+  src.query('foo AND bar AND unicorn'); // true
+  src.query('NOT(foo AND bar AND unicorn)'); // false
+  src.query('NOT(poo OR meh AND lol)'); // true
+  src.query('(NOT(NOT(yes))) OR NOT(foo AND unicorn)'); // false
+  src.query('(NOT(NOT(unicorn))) OR NOT(meh AND unicorn)'); // true
 ```
 
 ### License

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,59 +1,57 @@
 /**
- * Created by Umayr Shahid on 4/28/16.
+ * Created by Umayr Shahid <umayrr@hotmail.co.uk> on 28th April 2016.
  */
 
 'use strict';
 
-const ParenthesisRegex = /\([^()"]*(?:"[^"]*"[^()"]*)*\)/;
 const Dictionary = Object.freeze({
   'AND': '&&',
-  'OR': '||'
+  'OR': '||',
+  'NOT': '!'
 });
 
 const evaluate = require('safe-eval');
 
+const substitute = {
+  'object': function handleObject(src, text) {
+    let keys = Object.keys(src);
+    if (keys.length < 1) throw new Error('slq: target object should not be empty');
+    keys.forEach(key => text = text.split(key).join(src[key]));
+
+    return text;
+  },
+  'array': function handleArray(src, text) {
+    if (src.length < 1) throw new Error('slq: target array should not be empty');
+    text
+      .split(/[^\w\s]/gi)
+      .join('')
+      .trim()
+      .replace(/  +/g, ' ')
+      .split(' ')
+      .forEach(item => text = text.split(item).join(String(src.indexOf(item) > -1)));
+    return text;
+  }
+};
+
 class Slq {
   constructor(target) {
     this.target = target;
+    this.type = !Array.isArray(target) ? (this.target === Object(this.target) ? 'object' : null) : 'array';
+
+    if (!this.type) throw new Error('slq: target should be either object or an array');
   }
 
   query(q) {
     if (q === void 0 || q === '') throw new Error('slq: query should not be empty');
-    let matches = q.match(ParenthesisRegex);
+    q = substitute[typeof Dictionary](Dictionary, q);
+    q = substitute[this.type](this.target, q);
+    try {
+      return evaluate(q);
+    } catch (e) {
+      if (e.message === 'Unexpected identifier') throw new Error('slq: invalid operator/key');
+      throw new Error('slq: illegal expression');
+    }
 
-    if (!matches) return this.evaluate(q);
-
-    matches.forEach(match => {
-      let result = this.evaluate(match);
-      q = q.replace(match, result);
-    });
-
-    return this.query(q);
-  }
-
-  substitute(value) {
-    value = String(value);
-    if (value === 'true' || value === 'false') return value;
-    return this.target[value];
-  }
-
-  trim(value) {
-    value = String(value).trim();
-
-    if (value.indexOf('(') > -1) value = value.slice(1);
-    if (value.indexOf(')') > -1) value = value.slice(0, -1);
-
-    return value;
-  }
-
-  evaluate(value) {
-    value = this.trim(value);
-
-    let parts = value.split(' ');
-    let operator = Dictionary[parts[1]];
-    if (operator === void 0) throw new Error('slq: invalid operator');
-
-    return evaluate(`${this.substitute(parts[0])} ${operator} ${this.substitute(parts[2])}`);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slq",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Perform simple logical queries on javascript object and arrays",
   "main": "lib/index.js",
   "scripts": {
@@ -16,11 +16,11 @@
   },
   "keywords": [
     "simple logical query",
-    "and operation",
-    "or operation",
-    "nor operation",
-    "nand operation",
-    "string queries"
+    "and operator",
+    "or operator",
+    "not operator",
+    "string queries on object",
+    "string queries on arrays"
   ],
   "author": "Umayr Shahid <umayrr@hotmail.co.uk>",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 /**
- * Created by Umayr Shahid on 4/28/16.
+ * Created by Umayr Shahid <umayrr@hotmail.co.uk> on 28th April 2016.
  */
 
 'use strict';
@@ -9,56 +9,139 @@ const expect = require('chai').expect;
 describe('slq', () => {
   const Slq = require('../lib');
 
-  describe('#query', ()=> {
+  describe('#query', () => {
+    it('should throw exception if invalid operator is provided', () => {
+      let s = new Slq({foo: true});
 
-    let src = new Slq({
-      foo: true,
-      bar: false,
-      baz: false
+      expect(s.query.bind(s, 'baz LOL foo')).to.throw(Error);
+      expect(s.query.bind(s, 'baz LOL foo')).to.throw(/slq: invalid operator\/key/);
     });
 
-    it('should be false when `foo AND bar`', () => {
-      expect(src.query('foo AND bar')).to.be.false;
+    it('should throw exception if no query is provided', () => {
+      let s = new Slq({foo: true});
+
+      expect(s.query.bind(s, '')).to.throw(Error);
+      expect(s.query.bind(s, '')).to.throw(/slq: query should not be empty/);
+      expect(s.query.bind(s)).to.throw(Error);
+      expect(s.query.bind(s)).to.throw(/slq: query should not be empty/);
     });
 
-    it('should be false when `(foo AND bar) AND baz`', () => {
-      expect(src.query('(foo AND bar) AND baz')).to.be.false;
+    it('should throw exception if provided with empty target object', () => {
+      let s = new Slq({});
+
+      expect(s.query.bind(s, 'lol AND lmao')).to.throw(Error);
+      expect(s.query.bind(s, 'lol AND lmao')).to.throw(/slq: target object should not be empty/);
     });
 
-    it('should be false when `foo AND (bar AND baz)`', () => {
-      expect(src.query('foo AND (bar AND baz)')).to.be.false;
+    it('should throw exception if not provided with either object or array', () => {
+      function fn() {
+        new Slq('')
+      }
+
+      expect(fn).to.throw(Error);
+      expect(fn).to.throw(/slq: target should be either object or an array/);
     });
 
-    it('should be false when `foo AND (foo AND (bar AND baz))`', () => {
-      expect(src.query('foo AND (foo AND (bar AND baz))')).to.be.false;
+    it('should throw exception if provided illegal expression', () => {
+      let s = new Slq({foo: true});
+
+      expect(s.query.bind(s, 'lol 2132312 !! asdasmmAAA lmao')).to.throw(Error);
+      expect(s.query.bind(s, 'lol AND lmao')).to.throw(/slq: illegal expression/);
     });
 
-    it('should be true when `foo AND (foo AND foo)`', () => {
-      expect(src.query('foo AND (foo AND foo)')).to.be.true;
+    it('should be not work when provided with non-existent keys', () => {
+      let s = new Slq({foo: true});
+      expect(s.query.bind(s, 'NOT (unicorn AND NOT bar)')).to.throw(Error);
     });
 
-    it('should be true when `foo AND (foo OR bar)`', () => {
-      expect(src.query('foo AND (foo OR bar)')).to.be.true;
+    describe('#object', () => {
+
+      let src = new Slq({
+        foo: true,
+        bar: false,
+        baz: false
+      });
+
+      it('should be false when `foo AND bar`', () => {
+        expect(src.query('foo AND bar')).to.be.false;
+      });
+
+      it('should be true when `foo AND NOT bar`', () => {
+        expect(src.query('foo AND NOT bar')).to.be.true;
+      });
+
+      it('should be false when `NOT (foo AND NOT bar)`', () => {
+        expect(src.query('NOT (foo AND NOT bar)')).to.be.false;
+      });
+
+      it('should be false when `(foo AND bar) AND baz`', () => {
+        expect(src.query('(foo AND bar) AND baz')).to.be.false;
+      });
+
+      it('should be false when `NOT(NOT((foo AND bar) AND baz))`', () => {
+        expect(src.query('NOT(NOT((foo AND bar) AND baz))')).to.be.false;
+      });
+
+      it('should be false when `foo AND (bar AND baz)`', () => {
+        expect(src.query('foo AND (bar AND baz)')).to.be.false;
+      });
+
+      it('should be false when `foo AND (foo AND (bar AND baz))`', () => {
+        expect(src.query('foo AND (foo AND (bar AND baz))')).to.be.false;
+      });
+
+      it('should be true when `foo AND (foo AND foo)`', () => {
+        expect(src.query('foo AND (foo AND foo)')).to.be.true;
+      });
+
+      it('should be true when `foo AND (foo OR bar)`', () => {
+        expect(src.query('foo AND (foo OR bar)')).to.be.true;
+      });
+
+      it('should be true when `foo OR (foo AND bar)`', () => {
+        expect(src.query('foo OR (foo AND bar)')).to.be.true;
+      });
+
+      it('should be true when `baz OR (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))`', () => {
+        expect(src.query('baz OR (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))')).to.be.true;
+      });
+
+      it('should be true when `NOT baz AND (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))`', () => {
+        expect(src.query('NOT baz AND (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))')).to.be.true;
+      });
     });
 
-    it('should be true when `foo OR (foo AND bar)`', () => {
-      expect(src.query('foo OR (foo AND bar)')).to.be.true;
-    });
+    describe('#array', () => {
+      let src = new Slq(['foo', 'bar', 'unicorn']);
 
-    it('should be true when `baz OR (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))`', () => {
-      expect(src.query('baz OR (foo AND (foo OR (foo AND (bar OR (foo AND (baz OR foo))))))')).to.be.true;
-    });
+      it('should be true when `foo AND bar AND unicorn`', () => {
+        expect(src.query('foo AND bar AND unicorn')).to.be.true;
+      });
 
-    it('should throw error if invalid operator is provided', () => {
-      expect(src.query.bind(src, 'baz LOL foo')).to.throw(Error);
-      expect(src.query.bind(src, 'baz LOL foo')).to.throw(/slq: invalid operator/);
-    });
+      it('should be true when `foo AND bar AND unicorn` and a LOT of spaces & tabs', () => {
+        expect(src.query('foo         AND    bar                    AND unicorn')).to.be.true;
+      });
 
-    it('should throw error if no query is provided', () => {
-      expect(src.query.bind(src, '')).to.throw(Error);
-      expect(src.query.bind(src, '')).to.throw(/slq: query should not be empty/);
-      expect(src.query.bind(src)).to.throw(Error);
-      expect(src.query.bind(src)).to.throw(/slq: query should not be empty/);
+      it('should be false when `NOT(foo AND bar AND unicorn)`', () => {
+        expect(src.query('NOT(foo AND bar AND unicorn)')).to.be.false;
+      });
+
+      it('should be true when `NOT(poo OR meh AND lol)`', () => {
+        expect(src.query('NOT(poo OR meh AND lol)')).to.be.true;
+      });
+
+      it('should be false when `(NOT(NOT(yes))) OR NOT(foo AND unicorn)`', () => {
+        expect(src.query('(NOT(NOT(yes))) OR NOT(foo AND unicorn)')).to.be.false;
+      });
+
+      it('should be true when `(NOT(NOT(unicorn))) OR NOT(meh AND unicorn)`', () => {
+        expect(src.query('(NOT(NOT(unicorn))) OR NOT(meh AND unicorn)')).to.be.true;
+      });
+
+      it('should be true when `(!(!(unicorn))) || !(meh && unicorn)` with actual operators', () => {
+        expect(src.query('(!(!(unicorn))) || !(meh && unicorn)')).to.be.true;
+      });
     });
   });
+
 });


### PR DESCRIPTION
Previously, I was doing it by a recursive approach that gets the
innermost parenthesis and evaluate the condition and then so on.

While now, I'm building an expression using a dictionary of operators
and then evaluate it once.

Moreover, now it supports `NOT` too.